### PR TITLE
refactor : [로그인] session 저장소를 remote storage로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.15.2'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 

--- a/src/main/java/com/carrotbay/domain/user/UserController.java
+++ b/src/main/java/com/carrotbay/domain/user/UserController.java
@@ -57,7 +57,8 @@ public class UserController {
 
 	@PutMapping("/logout")
 	public ResponseEntity<?> logout(HttpSession httpSession) {
-		httpSession.removeAttribute(SESSION_KEY);
-		return new ResponseEntity<>(null, HttpStatus.OK);
+		httpSession.invalidate();
+		return new ResponseEntity<>("success", HttpStatus.OK);
 	}
+
 }


### PR DESCRIPTION

레디스를 세션 저장소로 선택한 이유는 레디스는 memcached와 달리 세션과 관련된 기능을 지원하기떄문입니다.
레디스는 해시 타입을 사용해 세션데이터를 일부 속성만 빠르게 수정 할 수 있고  TTL 관리나 세션 갱신도 유연하게 지원하기 때문에 복잡한 세션 관리에 유리합니다. 반면, Memcached는 value 전체를 꺼내고 다시 저장해야 하기 때문에 세션의 일부분만 수정하는 작업이 비효율적입니다.

또한 Redis는 Sentinel이나 Cluster 기능을 통해 고가용성과 수평 확장을 지원합니다. Sentinel은 Redis 서버를 지속적으로 모니터링하고, Master 노드 장애 발생 시 자동으로 다른 노드를 Master로 승격시키며, 클라이언트 연결을 자동으로 재구성해 서비스 가용성을 유지해줍니다. 이를 통해 대규모 서비스에서도 안정성과 운영 편의성을 확보할 수 있습니다.

마지막으로 Redis는 싱글 스레드 기반으로 동작하기 때문에, 멀티 스레드 기반인 Memcached와 달리 락 경합이나 컨텍스트 스위칭과 같은 비용이 발생하지 않습니다. 이러한 아키텍처 덕분에 Redis는 단일 스레드임에도 불구하고 Memcached에 필적하거나 더 나은 성능을 보여주는 경우도 많습니다.
